### PR TITLE
All Country support and login improvment

### DIFF
--- a/const.go
+++ b/const.go
@@ -10,6 +10,7 @@ const ApplicationId = "d89443d2-327c-4a6f-89e5-496bbb0317db"
 // API Endpoints
 const BaseUrlUS = "https://share2.dexcom.com/ShareWebServices/Services"
 const BaseUrlOUS = "https://shareous1.dexcom.com/ShareWebServices/Services"
+const BaseUrlJP = "https://share.dexcom.jp/ShareWebServices/Services/"
 const LoginPath = "/General/LoginPublisherAccountByName"
 const LoginPathId = "/General/LoginPublisherAccountById"
 const AuthPath = "/General/AuthenticatePublisherAccount"

--- a/const.go
+++ b/const.go
@@ -5,10 +5,11 @@ package dexcomshare
 
 // Application ID foud by a previous reverse engineering of the share app done by the user
 // who wrote the above docs
-const ApplicationId = "d8665ade-9673-4e27-9ff6-92db4ce13d13"
+const ApplicationId = "d89443d2-327c-4a6f-89e5-496bbb0317db"
 
 // API Endpoints
 const BaseUrlUS = "https://share2.dexcom.com/ShareWebServices/Services"
+const BaseUrlOUS = "https://shareous1.dexcom.com/ShareWebServices/Services"
 const LoginPath = "/General/LoginPublisherAccountByName"
 const AuthPath = "/General/AuthenticatePublisherAccount"
 const CurrentEGVPath = "/Publisher/ReadPublisherLatestGlucoseValues"

--- a/const.go
+++ b/const.go
@@ -11,6 +11,7 @@ const ApplicationId = "d89443d2-327c-4a6f-89e5-496bbb0317db"
 const BaseUrlUS = "https://share2.dexcom.com/ShareWebServices/Services"
 const BaseUrlOUS = "https://shareous1.dexcom.com/ShareWebServices/Services"
 const LoginPath = "/General/LoginPublisherAccountByName"
+const LoginPathId = "/General/LoginPublisherAccountById"
 const AuthPath = "/General/AuthenticatePublisherAccount"
 const CurrentEGVPath = "/Publisher/ReadPublisherLatestGlucoseValues"
 

--- a/const.go
+++ b/const.go
@@ -5,7 +5,9 @@ package dexcomshare
 
 // Application ID foud by a previous reverse engineering of the share app done by the user
 // who wrote the above docs
-const ApplicationId = "d89443d2-327c-4a6f-89e5-496bbb0317db"
+const ApplicationIdUS = "d89443d2-327c-4a6f-89e5-496bbb0317db"
+const ApplicationIdOUS = ApplicationIdUS
+const ApplicationIdJP = "d8665ade-9673-4e27-9ff6-92db4ce13d13"
 
 // API Endpoints
 const BaseUrlUS = "https://share2.dexcom.com/ShareWebServices/Services"

--- a/dexcomshare.go
+++ b/dexcomshare.go
@@ -30,10 +30,26 @@ type EstimatedGlucoseValue struct {
 	TrendArrow string
 }
 
+// Function to make a POST request to the Dexcom API.
+func DexcomAPIRequest(url string, payload []byte) (*http.Response, error) {
+	res, err := Post(url, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check if the response status is OK
+	if res.StatusCode != http.StatusOK {
+		return nil, errors.New("API request failed with status: " + res.Status)
+	}
+
+	return res, nil
+}
+
 // Log into Dexcom with your username and password.
 func Login(username string, password string, region string) (*DexcomSession, error) {
 	var needToAuth bool
 	var accountId string
+	var ApplicationId string
 
 	if IsEmail(username) {
 		// conitnue auth
@@ -50,8 +66,13 @@ func Login(username string, password string, region string) (*DexcomSession, err
 	switch region {
 	case "us":
 		BaseUrl = BaseUrlUS
+		ApplicationId = ApplicationIdUS
 	case "ous":
 		BaseUrl = BaseUrlOUS
+		ApplicationId = ApplicationIdOUS
+	case "jp":
+		BaseUrl = BaseUrlJP
+		ApplicationId = ApplicationIdJP
 	default:
 		return nil, errors.New("invalid region specified, use 'us' or 'ous'")
 	}

--- a/dexcomshare_test.go
+++ b/dexcomshare_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestGetLatestEGV(t *testing.T) {
-	dexcom, err := Login("USERNAME", "PASSWORD", "REGION")
+	dexcom, err := Login("USERNAME||UUID", "PASSWORD", "REGION")
 	if err != nil {
 		t.Error(err)
 	}
@@ -17,7 +17,7 @@ func TestGetLatestEGV(t *testing.T) {
 }
 
 func TestGetEGV(t *testing.T) {
-	dexcom, err := Login("USERNAME", "PASSWORD", "REGION")
+	dexcom, err := Login("USERNAME||UUID", "PASSWORD", "REGION")
 	if err != nil {
 		t.Error(err)
 	}

--- a/dexcomshare_test.go
+++ b/dexcomshare_test.go
@@ -17,7 +17,7 @@ func TestGetLatestEGV(t *testing.T) {
 }
 
 func TestGetEGV(t *testing.T) {
-	dexcom, err := Login("USERNAME", "PASSWORD")
+	dexcom, err := Login("USERNAME", "PASSWORD", "REGION")
 	if err != nil {
 		t.Error(err)
 	}

--- a/dexcomshare_test.go
+++ b/dexcomshare_test.go
@@ -2,10 +2,12 @@ package dexcomshare
 
 import (
 	"testing"
+
+	"github.com/cjcocokrisp/go-dexcomshare"
 )
 
 func TestGetLatestEGV(t *testing.T) {
-	dexcom, err := Login("USERNAME||UUID", "PASSWORD", "REGION")
+	dexcom, err := Login("USERNAME||UUID", "PASSWORD", dexcomshare.RegionUS)
 	if err != nil {
 		t.Error(err)
 	}
@@ -17,7 +19,7 @@ func TestGetLatestEGV(t *testing.T) {
 }
 
 func TestGetEGV(t *testing.T) {
-	dexcom, err := Login("USERNAME||UUID", "PASSWORD", "REGION")
+	dexcom, err := Login("USERNAME||UUID", "PASSWORD", dexcomshare.RegionUS)
 	if err != nil {
 		t.Error(err)
 	}

--- a/dexcomshare_test.go
+++ b/dexcomshare_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestGetLatestEGV(t *testing.T) {
-	dexcom, err := Login("USERNAME", "PASSWORD")
+	dexcom, err := Login("USERNAME", "PASSWORD", "REGION")
 	if err != nil {
 		t.Error(err)
 	}

--- a/utils.go
+++ b/utils.go
@@ -2,7 +2,6 @@ package dexcomshare
 
 import (
 	"bytes"
-	"errors"
 	"net/http"
 	"regexp"
 	"time"
@@ -27,18 +26,4 @@ func IsEmail(inputStr string) bool {
 func IsUUID(inputStr string) bool {
 	uuidRegex := regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
 	return uuidRegex.MatchString(inputStr)
-}
-
-func DexcomAPIRequest(url string, payload []byte) (*http.Response, error) {
-	res, err := Post(url, payload)
-	if err != nil {
-		return nil, err
-	}
-
-	// Check if the response status is OK
-	if res.StatusCode != http.StatusOK {
-		return nil, errors.New("API request failed with status: " + res.Status)
-	}
-
-	return res, nil
 }

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,44 @@
+package dexcomshare
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"regexp"
+	"time"
+)
+
+func Post(url string, body []byte) (*http.Response, error) {
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Content-Type", "application/json")
+	client := &http.Client{Timeout: 10 * time.Second}
+	return client.Do(req)
+}
+
+func IsEmail(inputStr string) bool {
+	emailRegex := regexp.MustCompile(`^[^@]+@[^@]+\.[^@]+$`)
+	return emailRegex.MatchString(inputStr)
+}
+
+func IsUUID(inputStr string) bool {
+	uuidRegex := regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+	return uuidRegex.MatchString(inputStr)
+}
+
+func DexcomAPIRequest(url string, payload []byte) (*http.Response, error) {
+	res, err := Post(url, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check if the response status is OK
+	if res.StatusCode != http.StatusOK {
+		return nil, errors.New("API request failed with status: " + res.Status)
+	}
+
+	return res, nil
+}


### PR DESCRIPTION
I'm from outside US so I wanted to make it possible to login from other countries.

1.  To be able to login from outside US, I've added in the const.go I've added:
```
const BaseUrlOUS = "https://shareous1.dexcom.com/ShareWebServices/Services"
const BaseUrlJP = "https://share.dexcom.jp/ShareWebServices/Services/"
``` 
got does from [pydexcom](https://github.com/gagebenne/pydexcom)

2. during the integration I struggled a bit with the login process therefore I've added logic to first get your accountId. Now you can directly use AccountId or E-Mail, either way the login will succeed as it always logs in with the accountId and uses `const LoginPathId = "/General/LoginPublisherAccountById`
3. While working on the code I've added utils.go, for non dexcom related functions and to cleanup the code a bit (at least imo)
4. Added DexcomAPIRequest function to dexcomshare.go

_As this is my first github contribution, I'm not to sure on how to handle a pull request. Let me know it this is ok for you, or ?contact? me if you have any further questions._


